### PR TITLE
Version 1.1.0: create new field for curse

### DIFF
--- a/schema/manifestV1.json
+++ b/schema/manifestV1.json
@@ -25,7 +25,8 @@
             "sha1Hash": "The sha1 hash of the jar",
             "downloadUrls": [
                 "Links should not require any form of user interaction to be downloaded"
-            ]
+            ],
+            "curseDownloadAvailable": true
         }
     ]
 }


### PR DESCRIPTION
Due to CF disallowing the storage of download links, a separate boolean has been made for curse instead. If the boolean is true, a consumer can make an api call by themselves to obtain the file if they want